### PR TITLE
golint straightforward fixes in all files

### DIFF
--- a/actions/deletecursor.go
+++ b/actions/deletecursor.go
@@ -43,7 +43,7 @@ func DeleteCursor(From, To demodel.Position, buff *demodel.CharBuffer) {
 
 		// now adjust dot if it was inside the deleted range..
 		if buff.Dot.Start == dot.Start {
-			buff.Dot.Start -= 1
+			buff.Dot.Start--
 			buff.Dot.End = buff.Dot.Start
 		}
 	} else {

--- a/actions/savefile.go
+++ b/actions/savefile.go
@@ -8,12 +8,12 @@ import (
 	//"os"
 )
 
-var NoFile error = errors.New("Can not save empty filename or nil buffer.")
+var ErrNoFile = errors.New("Can not save empty filename or nil buffer.")
 
 func SaveFile(From, To demodel.Position, buff *demodel.CharBuffer) error {
 	if buff == nil || buff.Filename == "" {
 		buff.AppendTag("\nNo file to Save")
-		return NoFile
+		return ErrNoFile
 	}
 
 	// we don't care about positions, just write the file

--- a/demodel/charbuffer.go
+++ b/demodel/charbuffer.go
@@ -8,11 +8,11 @@ import (
 	"unicode"
 )
 
-var NoTagline = errors.New("No tagline exists for buffer")
+var ErrNoTagline = errors.New("No tagline exists for buffer")
 
 func (c *CharBuffer) AppendTag(val string) error {
 	if c == nil || c.Tagline == nil {
-		return NoTagline
+		return ErrNoTagline
 	}
 
 	c.Tagline.Buffer = append(c.Tagline.Buffer, []byte(val)...)

--- a/demodel/viewer.go
+++ b/demodel/viewer.go
@@ -6,7 +6,7 @@ import (
 	"image/draw"
 )
 
-var UnsupportedOption error = errors.New("Unsupported Option")
+var ErrUnsupportedOption = errors.New("Unsupported Option")
 
 // A Renderer takes a character buffer and renders it to an image to be displayed in a viewport.
 type Renderer interface {

--- a/kbmap/deletemode.go
+++ b/kbmap/deletemode.go
@@ -14,7 +14,7 @@ func deleteMap(e key.Event, buff *demodel.CharBuffer, v demodel.Viewport) (demod
 		return DeleteMode, demodel.DirectionNone, nil
 	}
 	if buff == nil {
-		return NormalMode, demodel.DirectionNone, Invalid
+		return NormalMode, demodel.DirectionNone, ErrInvalid
 	}
 
 	// since some keys we're modify dot before calling DeleteCursor, we need to back it up
@@ -104,13 +104,13 @@ func deleteMap(e key.Event, buff *demodel.CharBuffer, v demodel.Viewport) (demod
 		buff.Undo.Dot = undoDot
 		return NormalMode, demodel.DirectionUp, nil
 	case key.CodeRightArrow:
-		return DeleteMode, demodel.DirectionUp, ScrollRight
+		return DeleteMode, demodel.DirectionUp, ErrScrollRight
 	case key.CodeLeftArrow:
-		return DeleteMode, demodel.DirectionUp, ScrollLeft
+		return DeleteMode, demodel.DirectionUp, ErrScrollLeft
 	case key.CodeDownArrow:
-		return DeleteMode, demodel.DirectionUp, ScrollDown
+		return DeleteMode, demodel.DirectionUp, ErrScrollDown
 	case key.CodeUpArrow:
-		return DeleteMode, demodel.DirectionUp, ScrollUp
+		return DeleteMode, demodel.DirectionUp, ErrScrollUp
 	case key.Code4:
 		// $ is pressed, in most key maps..
 
@@ -158,5 +158,5 @@ func deleteMap(e key.Event, buff *demodel.CharBuffer, v demodel.Viewport) (demod
 			return DeleteMode, demodel.DirectionNone, nil
 		}
 	}
-	return DeleteMode, demodel.DirectionNone, Invalid
+	return DeleteMode, demodel.DirectionNone, ErrInvalid
 }

--- a/kbmap/kbmap.go
+++ b/kbmap/kbmap.go
@@ -10,12 +10,12 @@ import (
 // might potentially scroll the buffer, so that it knows if it should scroll from
 // the start, or the end Dot when it goes out of view.
 
-var Invalid error = errors.New("Invalid keyboard map.")
-var ExitProgram error = errors.New("Keystroke wants to exit the program.")
-var ScrollDown error = errors.New("Keystroke wants to scroll the window down.")
-var ScrollUp error = errors.New("Keystroke wants to scroll the window up.")
-var ScrollLeft error = errors.New("Keystroke wants to scroll the window left.")
-var ScrollRight error = errors.New("Keystroke wants to scroll the window right.")
+var ErrInvalid = errors.New("Invalid keyboard map.")
+var ErrExitProgram = errors.New("Keystroke wants to exit the program.")
+var ErrScrollDown = errors.New("Keystroke wants to scroll the window down.")
+var ErrScrollUp = errors.New("Keystroke wants to scroll the window up.")
+var ErrScrollLeft = errors.New("Keystroke wants to scroll the window left.")
+var ErrScrollRight = errors.New("Keystroke wants to scroll the window right.")
 
 type defaultMaps uint
 
@@ -37,6 +37,6 @@ func (m defaultMaps) HandleKey(e key.Event, buff *demodel.CharBuffer, v demodel.
 	case TagMode:
 		return tagMap(e, buff, v)
 	}
-	return nil, demodel.DirectionNone, Invalid
+	return nil, demodel.DirectionNone, ErrInvalid
 
 }

--- a/kbmap/normalmode.go
+++ b/kbmap/normalmode.go
@@ -17,7 +17,7 @@ func normalMap(e key.Event, buff *demodel.CharBuffer, v demodel.Viewport) (demod
 		return NormalMode, demodel.DirectionNone, nil
 	}
 	if buff == nil {
-		return NormalMode, demodel.DirectionNone, Invalid
+		return NormalMode, demodel.DirectionNone, ErrInvalid
 	}
 	switch e.Code {
 	case key.CodeEscape:
@@ -187,13 +187,13 @@ func normalMap(e key.Event, buff *demodel.CharBuffer, v demodel.Viewport) (demod
 		// Arrow keys indicate their scroll direction via the error return value,
 		// they return demodel.DirectionNone to make sure both code paths don't accidentally
 		// get triggered
-		return NormalMode, demodel.DirectionNone, ScrollRight
+		return NormalMode, demodel.DirectionNone, ErrScrollRight
 	case key.CodeLeftArrow:
-		return NormalMode, demodel.DirectionNone, ScrollLeft
+		return NormalMode, demodel.DirectionNone, ErrScrollLeft
 	case key.CodeDownArrow:
-		return NormalMode, demodel.DirectionNone, ScrollDown
+		return NormalMode, demodel.DirectionNone, ErrScrollDown
 	case key.CodeUpArrow:
-		return NormalMode, demodel.DirectionNone, ScrollUp
+		return NormalMode, demodel.DirectionNone, ErrScrollUp
 	case key.Code0:
 		if e.Modifiers == 0 {
 			Repeat *= 10
@@ -370,5 +370,5 @@ func normalMap(e key.Event, buff *demodel.CharBuffer, v demodel.Viewport) (demod
 			return NormalMode, demodel.DirectionNone, nil
 		}
 	}
-	return NormalMode, demodel.DirectionNone, Invalid
+	return NormalMode, demodel.DirectionNone, ErrInvalid
 }

--- a/main.go
+++ b/main.go
@@ -214,18 +214,18 @@ func main() {
 				// special error codes that a keystroke can send to control the
 				// program
 				switch err {
-				case kbmap.ExitProgram:
+				case kbmap.ErrExitProgram:
 					if !buff.Dirty {
 						return
 					}
-				case kbmap.ScrollUp:
+				case kbmap.ErrScrollUp:
 					scrollSize := getKbScrollSizeY(e, wSize)
 
 					viewport.Location.Y -= scrollSize
 					if viewport.Location.Y < 0 {
 						viewport.Location.Y = 0
 					}
-				case kbmap.ScrollDown:
+				case kbmap.ErrScrollDown:
 					scrollSize := getKbScrollSizeY(e, wSize)
 
 					viewport.Location.Y += scrollSize
@@ -234,13 +234,13 @@ func main() {
 						// the last
 						viewport.Location.Y = imgSize.Max.Y - wSize.Y + 50
 					}
-				case kbmap.ScrollLeft:
+				case kbmap.ErrScrollLeft:
 					scrollSize := getKbScrollSizeX(e, wSize)
 					viewport.Location.X -= scrollSize
 					if viewport.Location.X < 0 {
 						viewport.Location.X = 0
 					}
-				case kbmap.ScrollRight:
+				case kbmap.ErrScrollRight:
 					scrollSize := getKbScrollSizeX(e, wSize)
 					viewport.Location.X += scrollSize
 					// we've scrolled too far down
@@ -375,7 +375,7 @@ func main() {
 				// mouse button. Left or right clicking uses the normal dot, middle uses
 				// the alternate so that things can be executed with parameters other than
 				// themselves.
-				var eDot *demodel.Dot = &evtBuff.Dot
+				var eDot = &evtBuff.Dot
 				/*
 						This doesn't seem to be working well enough to use yet.
 					if e.Button == mouse.ButtonMiddle {

--- a/plugins/redmine/redmine.go
+++ b/plugins/redmine/redmine.go
@@ -27,11 +27,11 @@ type redmineIssueList struct {
 	Issues []redmineIssue `json:"issues"`
 }
 type redmineField struct {
-	Id   int    `json:"id"`
+	ID   int    `json:"id"`
 	Name string `json:"name"`
 }
 type redmineIssue struct {
-	Id          int `json:"id"`
+	ID          int `json:"id"`
 	Subject     string
 	Description string
 	Priority    redmineField `json:"priority"`
@@ -64,7 +64,7 @@ type redmineProjects struct {
 	Projects []redmineProject `json:"projects"`
 }
 type redmineProject struct {
-	Id          int    `json:"id"`
+	ID          int    `json:"id"`
 	Name        string `json:"name"`
 	Identifier  string `json:"identifier"`
 	Description string `json:"description"`
@@ -197,7 +197,7 @@ func Redmine(args string, buff *demodel.CharBuffer, v demodel.Viewport) {
 			buff.AppendTag(err.Error())
 			return
 		}
-		fmt.Fprintf(&newBuffer, "Full URL: %s\nRedmine:%d\nAuthor:%s\nAssignee:%s\nPriority: %s\nStatus:%s\nSubject:%s\n\nDescription:\n%s\n", strings.TrimSuffix(url, ".json"+"?apikey="+apikey)+"/", issue.Id, issue.Author.Name, issue.AssignedTo.Name, issue.Priority.Name, issue.Status.Name, issue.Subject, strings.Replace(issue.Description, "\r", "", -1))
+		fmt.Fprintf(&newBuffer, "Full URL: %s\nRedmine:%d\nAuthor:%s\nAssignee:%s\nPriority: %s\nStatus:%s\nSubject:%s\n\nDescription:\n%s\n", strings.TrimSuffix(url, ".json"+"?apikey="+apikey)+"/", issue.ID, issue.Author.Name, issue.AssignedTo.Name, issue.Priority.Name, issue.Status.Name, issue.Subject, strings.Replace(issue.Description, "\r", "", -1))
 		buff.Filename = ""
 		buff.Buffer = newBuffer.Bytes()
 
@@ -238,7 +238,7 @@ func Redmine(args string, buff *demodel.CharBuffer, v demodel.Viewport) {
 		}
 		fmt.Fprintf(&newBuffer, "\n")
 		for _, issue := range issues.Issues {
-			fmt.Fprintf(&newBuffer, "Redmine:%d (%s)\n", issue.Id, issue.Subject)
+			fmt.Fprintf(&newBuffer, "Redmine:%d (%s)\n", issue.ID, issue.Subject)
 		}
 		buff.Filename = ""
 		buff.Buffer = newBuffer.Bytes()

--- a/plugins/redmine/redmine_test.go
+++ b/plugins/redmine/redmine_test.go
@@ -16,7 +16,7 @@ import (
 func TestParseRedmineProjectsJSON(t *testing.T) {
 	// Use a string form of the output from http://www.redmine.org/projects.json for
 	// a test
-	var rpTest string = `{"projects":[{"id":1,"name":"Redmine","identifier":"redmine","description":"Redmine is a flexible project management web application written using Ruby on Rails framework.","status":1,"created_on":"2007-09-29T10:03:04Z","updated_on":"2009-03-15T11:35:11Z"}],"total_count":1,"offset":0,"limit":25}`
+	var rpTest = `{"projects":[{"id":1,"name":"Redmine","identifier":"redmine","description":"Redmine is a flexible project management web application written using Ruby on Rails framework.","status":1,"created_on":"2007-09-29T10:03:04Z","updated_on":"2009-03-15T11:35:11Z"}],"total_count":1,"offset":0,"limit":25}`
 	projects, err := parseRedmineProjectJSON(strings.NewReader(rpTest))
 	if err != nil {
 		t.Errorf("Error while parsing basic Redmine projects.json output %v\n", err)
@@ -30,8 +30,8 @@ func TestParseRedmineProjectsJSON(t *testing.T) {
 	if projects.Projects[0].Identifier != "redmine" {
 		t.Errorf("Unxpected name for Project 1. Expected redmine got %s\n", projects.Projects[0].Identifier)
 	}
-	if projects.Projects[0].Id != 1 {
-		t.Errorf("Unxpected name for Project 1. Expected redmine got %d\n", projects.Projects[0].Id)
+	if projects.Projects[0].ID != 1 {
+		t.Errorf("Unxpected name for Project 1. Expected redmine got %d\n", projects.Projects[0].ID)
 	}
 }
 
@@ -52,8 +52,8 @@ func TestParseRedmineIssuesJSON(t *testing.T) {
 		t.Errorf("Unexpected number of issues parsed. Expected 25 got %d\n", len(issues.Issues))
 
 	}
-	if issues.Issues[0].Id != 22943 {
-		t.Errorf("Incorrect Id for first issue. Expect 22943 but got %d\n", issues.Issues[0].Id)
+	if issues.Issues[0].ID != 22943 {
+		t.Errorf("Incorrect Id for first issue. Expect 22943 but got %d\n", issues.Issues[0].ID)
 	}
 	if issues.Issues[0].Subject != "Transfer " {
 		t.Errorf("Unexpected subject for first issue. Expected \"Transfer \" got \"%s\"", issues.Issues[0].Subject)
@@ -70,8 +70,8 @@ func TestParseRedmineIssueJSON(t *testing.T) {
 	if err != nil {
 		t.Fatal("Could not load JSON for test issue.")
 	}
-	if issue.Id != 22944 {
-		t.Errorf("Unexpected Id for issue. Expected 22944 got %d", issue.Id)
+	if issue.ID != 22944 {
+		t.Errorf("Unexpected Id for issue. Expected 22944 got %d", issue.ID)
 	}
 	if issue.Subject != "EDI Faturamento FIAT" {
 		t.Errorf("Incorrect title for parsed issue.")

--- a/plugins/shell/shell.go
+++ b/plugins/shell/shell.go
@@ -63,22 +63,22 @@ func (s shellKbmap) HandleKey(e key.Event, buff *demodel.CharBuffer, v demodel.V
 		// they return demodel.DirectionNone to make sure both code paths don't accidentally
 		// get triggered
 		if e.Direction == key.DirPress {
-			return s, demodel.DirectionNone, kbmap.ScrollRight
+			return s, demodel.DirectionNone, kbmap.ErrScrollRight
 		}
 		return s, demodel.DirectionNone, nil
 	case key.CodeLeftArrow:
 		if e.Direction == key.DirPress {
-			return s, demodel.DirectionNone, kbmap.ScrollLeft
+			return s, demodel.DirectionNone, kbmap.ErrScrollLeft
 		}
 		return s, demodel.DirectionNone, nil
 	case key.CodeDownArrow:
 		if e.Direction == key.DirPress {
-			return s, demodel.DirectionNone, kbmap.ScrollDown
+			return s, demodel.DirectionNone, kbmap.ErrScrollDown
 		}
 		return s, demodel.DirectionNone, nil
 	case key.CodeUpArrow:
 		if e.Direction == key.DirPress {
-			return s, demodel.DirectionNone, kbmap.ScrollUp
+			return s, demodel.DirectionNone, kbmap.ErrScrollUp
 		}
 		return s, demodel.DirectionNone, nil
 	// Special cases for control characters.

--- a/position/positions.go
+++ b/position/positions.go
@@ -7,7 +7,7 @@ import (
 	"unicode"
 )
 
-var Invalid error = errors.New("Invalid Position")
+var ErrInvalid = errors.New("Invalid Position")
 
 // DotStart can be used as a demodel.Position argument
 // to actions
@@ -35,27 +35,27 @@ func AltDotEnd(buff demodel.CharBuffer) (uint, error) {
 
 func TagDotStart(buff demodel.CharBuffer) (uint, error) {
 	if buff.Tagline == nil || len(buff.Tagline.Buffer) == 0 {
-		return 0, Invalid
+		return 0, ErrInvalid
 	}
 	return buff.Tagline.Dot.Start, nil
 }
 
 func TagDotEnd(buff demodel.CharBuffer) (uint, error) {
 	if buff.Tagline == nil || len(buff.Tagline.Buffer) == 0 {
-		return 0, Invalid
+		return 0, ErrInvalid
 	}
 	return buff.Tagline.Dot.End, nil
 }
 
 func TagAltDotStart(buff demodel.CharBuffer) (uint, error) {
 	if buff.Tagline == nil || len(buff.Tagline.Buffer) == 0 {
-		return 0, Invalid
+		return 0, ErrInvalid
 	}
 	return buff.Tagline.AltDot.Start, nil
 }
 func TagAltDotEnd(buff demodel.CharBuffer) (uint, error) {
 	if buff.Tagline == nil || len(buff.Tagline.Buffer) == 0 {
-		return 0, Invalid
+		return 0, ErrInvalid
 	}
 	return buff.Tagline.AltDot.End, nil
 }
@@ -64,18 +64,18 @@ func BuffStart(buff demodel.CharBuffer) (uint, error) {
 	if len(buff.Buffer) > 0 {
 		return 0, nil
 	}
-	return 0, Invalid
+	return 0, ErrInvalid
 }
 func BuffEnd(buff demodel.CharBuffer) (uint, error) {
 	if len(buff.Buffer) > 0 {
 		return uint(len(buff.Buffer) - 1), nil
 	}
-	return 0, Invalid
+	return 0, ErrInvalid
 }
 
 func PrevChar(buff demodel.CharBuffer) (uint, error) {
 	if buff.Dot.Start == 0 {
-		return 0, Invalid
+		return 0, ErrInvalid
 	}
 
 	// BUG: This doesn't deal with multibyte UTF-8 runes.
@@ -83,21 +83,21 @@ func PrevChar(buff demodel.CharBuffer) (uint, error) {
 }
 func NextChar(buff demodel.CharBuffer) (uint, error) {
 	if buff.Dot.End >= uint(len(buff.Buffer)) {
-		return uint(len(buff.Buffer)) - 1, Invalid
+		return uint(len(buff.Buffer)) - 1, ErrInvalid
 	}
 	return buff.Dot.End + 1, nil
 }
 
 func PrevLine(buff demodel.CharBuffer) (uint, error) {
 	// how far into the current line is the current character?
-	var lineIdx int = -1
+	var lineIdx = -1
 
 	// where does the previous line start, so that we can index
 	// lineIdx into it at the end?
 	var prevLineStart, curLineStart int = -1, -1
 	for i := buff.Dot.Start; i > 0; i-- {
 		if uint(len(buff.Buffer)) <= i {
-			return buff.Dot.End, Invalid
+			return buff.Dot.End, ErrInvalid
 		}
 		if buff.Buffer[i] == '\n' {
 			if lineIdx == -1 {
@@ -126,22 +126,22 @@ func PrevLine(buff demodel.CharBuffer) (uint, error) {
 func NextLine(buff demodel.CharBuffer) (uint, error) {
 	// special case. We're at a newline, so the next line is just the next character..
 	if len(buff.Buffer) == 0 {
-		return 0, Invalid
+		return 0, ErrInvalid
 	}
 	if buff.Dot.End >= uint(len(buff.Buffer)) {
-		return uint(len(buff.Buffer) - 1), Invalid
+		return uint(len(buff.Buffer) - 1), ErrInvalid
 	}
 	if buff.Buffer[buff.Dot.End] == '\n' {
 		return buff.Dot.End + 1, nil
 	}
 	// how far into the current line is the current character?
-	var lineIdx int = -1
+	var lineIdx = -1
 
 	// calculate how far we are into the current line.
 	var nextLineStart, subsequentLine int = -1, -1
 	for i := buff.Dot.End; i > 0; i-- {
 		if uint(len(buff.Buffer)) <= i {
-			return buff.Dot.End, Invalid
+			return buff.Dot.End, ErrInvalid
 		}
 		if buff.Buffer[i] == '\n' {
 			if lineIdx == -1 {
@@ -185,7 +185,7 @@ func NextLine(buff demodel.CharBuffer) (uint, error) {
 
 	if pos >= uint(len(buff.Buffer)) {
 		// overflowed the buffer somehow, so return the end of the buffer
-		return uint(len(buff.Buffer)) - 1, Invalid
+		return uint(len(buff.Buffer)) - 1, ErrInvalid
 	}
 
 	// the line starts at the character after the \n, not on the \n itself.
@@ -194,10 +194,10 @@ func NextLine(buff demodel.CharBuffer) (uint, error) {
 
 func EndOfLine(buff demodel.CharBuffer) (uint, error) {
 	if len(buff.Buffer) == 0 {
-		return 0, Invalid
+		return 0, ErrInvalid
 	}
 	if buff.Dot.End >= uint(len(buff.Buffer)) {
-		return uint(len(buff.Buffer)) - 1, Invalid
+		return uint(len(buff.Buffer)) - 1, ErrInvalid
 	}
 	if buff.Buffer[buff.Dot.End] == '\n' {
 		return buff.Dot.End, nil
@@ -212,7 +212,7 @@ func EndOfLine(buff demodel.CharBuffer) (uint, error) {
 
 func EndOfLineWithNewline(buff demodel.CharBuffer) (uint, error) {
 	if len(buff.Buffer) == 0 {
-		return 0, Invalid
+		return 0, ErrInvalid
 	}
 	if buff.Dot.End >= uint(len(buff.Buffer)) {
 		return uint(len(buff.Buffer)), nil
@@ -229,7 +229,7 @@ func EndOfLineWithNewline(buff demodel.CharBuffer) (uint, error) {
 }
 func StartOfLine(buff demodel.CharBuffer) (uint, error) {
 	if len(buff.Buffer) == 0 {
-		return 0, Invalid
+		return 0, ErrInvalid
 	}
 	if buff.Dot.Start == 0 {
 		return 0, nil
@@ -245,7 +245,7 @@ func StartOfLine(buff demodel.CharBuffer) (uint, error) {
 
 func CurWordStart(buff demodel.CharBuffer) (uint, error) {
 	if len(buff.Buffer) == 0 {
-		return 0, Invalid
+		return 0, ErrInvalid
 	}
 	if buff.Dot.Start == 0 {
 		return 0, nil
@@ -270,7 +270,7 @@ func CurWordStart(buff demodel.CharBuffer) (uint, error) {
 func CurWordEnd(buff demodel.CharBuffer) (uint, error) {
 	switch len(buff.Buffer) {
 	case 0:
-		return 0, Invalid
+		return 0, ErrInvalid
 	case 1:
 		return 0, nil
 	}
@@ -291,7 +291,7 @@ func CurWordEnd(buff demodel.CharBuffer) (uint, error) {
 }
 func CurExecutionWordStart(buff demodel.CharBuffer) (uint, error) {
 	if len(buff.Buffer) == 0 {
-		return 0, Invalid
+		return 0, ErrInvalid
 	}
 	if buff.Dot.Start == 0 {
 		return 0, nil
@@ -316,7 +316,7 @@ func CurExecutionWordStart(buff demodel.CharBuffer) (uint, error) {
 func CurExecutionWordEnd(buff demodel.CharBuffer) (uint, error) {
 	switch len(buff.Buffer) {
 	case 0:
-		return 0, Invalid
+		return 0, ErrInvalid
 	case 1:
 		return 0, nil
 	}
@@ -337,28 +337,28 @@ func CurExecutionWordEnd(buff demodel.CharBuffer) (uint, error) {
 }
 func CurTagExecutionWordStart(buff demodel.CharBuffer) (uint, error) {
 	if buff.Tagline == nil || len(buff.Tagline.Buffer) == 0 {
-		return 0, Invalid
+		return 0, ErrInvalid
 	}
 	return CurExecutionWordStart(*buff.Tagline)
 }
 
 func CurTagExecutionWordEnd(buff demodel.CharBuffer) (uint, error) {
 	if buff.Tagline == nil || len(buff.Tagline.Buffer) == 0 {
-		return 0, Invalid
+		return 0, ErrInvalid
 	}
 	return CurExecutionWordEnd(*buff.Tagline)
 
 }
 func CurTagWordStart(buff demodel.CharBuffer) (uint, error) {
 	if buff.Tagline == nil || len(buff.Tagline.Buffer) == 0 {
-		return 0, Invalid
+		return 0, ErrInvalid
 	}
 	return CurWordStart(*buff.Tagline)
 }
 
 func CurTagWordEnd(buff demodel.CharBuffer) (uint, error) {
 	if buff.Tagline == nil || len(buff.Tagline.Buffer) == 0 {
-		return 0, Invalid
+		return 0, ErrInvalid
 	}
 	return CurWordEnd(*buff.Tagline)
 
@@ -375,12 +375,12 @@ func NextWordStart(buff demodel.CharBuffer) (uint, error) {
 			}
 		}
 	}
-	return buff.Dot.End, Invalid
+	return buff.Dot.End, ErrInvalid
 }
 
 func PrevWordStart(buff demodel.CharBuffer) (uint, error) {
 	if len(buff.Buffer) == 0 || buff.Dot.Start >= uint(len(buff.Buffer)) {
-		return 0, Invalid
+		return 0, ErrInvalid
 	}
 	if buff.Dot.Start == 0 {
 		return 0, nil

--- a/renderer/imagemap.go
+++ b/renderer/imagemap.go
@@ -7,7 +7,7 @@ import (
 	"image"
 )
 
-var NoCharacter error = errors.New("No character under the mouse cursor.")
+var ErrNoCharacter = errors.New("No character under the mouse cursor.")
 
 type ImageLoc struct {
 	Loc fixed.Rectangle26_6
@@ -28,7 +28,7 @@ func (im ImageMap) At(x, y int) (uint, error) {
 			return m.Idx, nil
 		}
 	}
-	return 0, NoCharacter
+	return 0, ErrNoCharacter
 }
 
 // Returns the bounding rectangle for the character at index idx
@@ -42,5 +42,5 @@ func (im ImageMap) Get(idx uint) (image.Rectangle, error) {
 			}, nil
 		}
 	}
-	return image.ZR, NoCharacter
+	return image.ZR, ErrNoCharacter
 }

--- a/renderer/imagemapcacher.go
+++ b/renderer/imagemapcacher.go
@@ -7,7 +7,7 @@ import (
 	"image"
 )
 
-// An DefaultImageMapper is a type that can be mixed in to
+// DefaultImageMapper is a type that can be mixed in to
 // renderers to provide a default implementation of
 // GetImageMap() equivalent to what would be used by the
 // NoSyntaxRenderer.
@@ -17,8 +17,8 @@ type DefaultImageMapper struct {
 	IMap        *ImageMap
 }
 
-func (i *DefaultImageMapper) InvalidateCache() {
-	i.IMap = nil
+func (imap *DefaultImageMapper) InvalidateCache() {
+	imap.IMap = nil
 }
 func (imap *DefaultImageMapper) GetImageMap(buf *demodel.CharBuffer, viewport image.Rectangle) demodel.ImageMap {
 	if imap.IMap != nil && imap.LastBuf == buf && imap.LastBufSize == len(buf.Buffer) {

--- a/viewer/viewport.go
+++ b/viewer/viewport.go
@@ -40,12 +40,12 @@ func (v *Viewport) GetKeyboardMode() demodel.Map {
 	return v.Map
 }
 
-var KBLockedError error = errors.New("Keyboard mode is locked")
-var InvalidViewport error = errors.New("Invalid viewport")
+var ErrKBLocked = errors.New("Keyboard mode is locked")
+var ErrInvalidViewport = errors.New("Invalid viewport")
 
 func (v *Viewport) ResetLocation() error {
 	if v == nil {
-		return InvalidViewport
+		return ErrInvalidViewport
 	}
 	v.Location.X = 0
 	v.Location.Y = 0
@@ -56,7 +56,7 @@ func (v *Viewport) ResetLocation() error {
 // will fail.
 func (v *Viewport) LockKeyboardMode(m demodel.Map) error {
 	if v.kbLocked {
-		return KBLockedError
+		return ErrKBLocked
 	}
 	v.kbLocked = true
 	v.Map = m
@@ -67,17 +67,17 @@ func (v *Viewport) LockKeyboardMode(m demodel.Map) error {
 // parameter to ensure that it's the same caller that locked it.
 // It's not secure, but it prevents plugins from accidentally unlocking
 // someone else's locked keyboard.
-// Returns KBLockedError if d doesn't equal the mode that it's locked to.
+// Returns ErrKBLocked if d doesn't equal the mode that it's locked to.
 func (v *Viewport) UnlockKeyboardMode(d demodel.Map) error {
 	if v.Map == d {
 		v.kbLocked = false
 		return nil
 	}
-	return KBLockedError
+	return ErrKBLocked
 }
 func (v *Viewport) SetKeyboardMode(m demodel.Map) error {
 	if v.kbLocked {
-		return KBLockedError
+		return ErrKBLocked
 	}
 	v.Map = m
 	//fmt.Print("Set keyboard mode!")
@@ -109,7 +109,7 @@ func (v *Viewport) SetOption(opt string, val interface{}) error {
 		return fmt.Errorf("WarnAlpha must be in the range 0-255")
 
 	default:
-		return demodel.UnsupportedOption
+		return demodel.ErrUnsupportedOption
 	}
 }
 


### PR DESCRIPTION
This leaves the following golint warnings:

```
main.go:28:2: exported const ButtonLeft should have comment (or a comment on this block) or be unexported
actions/clipboard.go:8:1: exported function PasteClipboard should have comment or be unexported
actions/clipboard.go:51:1: exported function CopyClipboard should have comment or be unexported
actions/clipboard.go:73:1: exported function CutClipboard should have comment or be unexported
actions/deletecursor.go:7:1: exported function DeleteCursor should have comment or be unexported
actions/execute.go:21:1: exported function PerformAction should have comment or be unexported
actions/execute.go:43:1: exported function PerformTagAction should have comment or be unexported
actions/execute.go:79:1: exported function OpenOrPerformAction should have comment or be unexported
actions/execute.go:119:1: exported function RunOrExec should have comment or be unexported
actions/find.go:7:1: comment on exported function FindNext should be of the form "FindNext ..."
actions/find.go:38:1: exported function FindNextOrOpen should have comment or be unexported
actions/find.go:72:1: exported function FindNextOrOpenTag should have comment or be unexported
actions/insertcursor.go:7:1: exported function InsertSnarfBuffer should have comment or be unexported
actions/movecursor.go:7:1: exported function MoveCursor should have comment or be unexported
actions/open.go:117:1: exported function OpenFile should have comment or be unexported
actions/open.go:218:1: comment on exported function FocusViewport should be of the form "FocusViewport ..."
actions/register.go:14:1: exported function RegisterAction should have comment or be unexported
actions/savefile.go:11:5: exported var ErrNoFile should have comment or be unexported
actions/savefile.go:13:1: exported function SaveFile should have comment or be unexported
actions/defaults/defaultactions.go:51:1: exported function Put should have comment or be unexported
actions/defaults/defaultactions.go:57:1: exported function Get should have comment or be unexported
actions/defaults/defaultactions.go:70:1: exported function Exit should have comment or be unexported
actions/defaults/defaultactions.go:78:1: exported function ForceQuit should have comment or be unexported
actions/defaults/defaultactions.go:86:1: exported function SaveAndExit should have comment or be unexported
actions/defaults/defaultactions.go:92:1: exported function SaveOrExit should have comment or be unexported
actions/defaults/defaultactions.go:100:1: exported function Paste should have comment or be unexported
actions/defaults/defaultactions.go:104:1: exported function ResetTagline should have comment or be unexported
actions/defaults/defaultactions.go:108:1: exported function SwitchRenderer should have comment or be unexported
actions/defaults/undo.go:14:1: exported function Undo should have comment or be unexported
actions/defaults/viewport.go:18:1: exported function TermWidth should have comment or be unexported
actions/defaults/viewport.go:28:1: exported function WarnAlpha should have comment or be unexported
demodel/charbuffer.go:11:5: exported var ErrNoTagline should have comment or be unexported
demodel/charbuffer.go:13:1: exported method CharBuffer.AppendTag should have comment or be unexported
demodel/charbuffer.go:22:1: exported method CharBuffer.ResetTagline should have comment or be unexported
demodel/charbuffer.go:50:1: exported method CharBuffer.LoadSnarfBuffer should have comment or be unexported
demodel/charbuffer.go:63:1: exported method CharBuffer.JoinLines should have comment or be unexported
demodel/charbuffer.go:105:1: exported method CharBuffer.SaveSnarfBuffer should have comment or be unexported
demodel/model.go:54:1: comment on exported type Action should be of the form "Action ..." (with optional leading article)
demodel/model.go:58:1: comment on exported type Position should be of the form "Position ..." (with optional leading article)
demodel/model.go:73:6: exported type ScrollDirection should have comment or be unexported
demodel/model.go:76:2: exported const DirectionNone should have comment (or a comment on this block) or be unexported
demodel/viewer.go:9:5: exported var ErrUnsupportedOption should have comment or be unexported
kbmap/kbmap.go:13:5: exported var ErrInvalid should have comment or be unexported
kbmap/kbmap.go:14:5: exported var ErrExitProgram should have comment or be unexported
kbmap/kbmap.go:15:5: exported var ErrScrollDown should have comment or be unexported
kbmap/kbmap.go:16:5: exported var ErrScrollUp should have comment or be unexported
kbmap/kbmap.go:17:5: exported var ErrScrollLeft should have comment or be unexported
kbmap/kbmap.go:18:5: exported var ErrScrollRight should have comment or be unexported
kbmap/kbmap.go:23:2: exported const NormalMode should have comment (or a comment on this block) or be unexported
kbmap/normalmode.go:11:5: exported var Repeat should have comment or be unexported
plugins/shell/shell.go:22:1: comment on exported type TSBuffer should be of the form "TSBuffer ..." (with optional leading article)
plugins/shell/termrenderer.go:17:6: exported type TerminalRenderer should have comment or be unexported
plugins/shell/termrenderer.go:22:1: exported method TerminalRenderer.InvalidateCache should have comment or be unexported
plugins/shell/termrenderer.go:27:1: exported method TerminalRenderer.CanRender should have comment or be unexported
plugins/shell/termrenderer.go:31:1: exported method TerminalRenderer.RenderInto should have comment or be unexported
position/positions.go:10:5: exported var ErrInvalid should have comment or be unexported
position/positions.go:24:1: comment on exported function AltDotStart should be of the form "AltDotStart ..."
position/positions.go:30:1: comment on exported function AltDotEnd should be of the form "AltDotEnd ..."
position/positions.go:36:1: exported function TagDotStart should have comment or be unexported
position/positions.go:43:1: exported function TagDotEnd should have comment or be unexported
position/positions.go:50:1: exported function TagAltDotStart should have comment or be unexported
position/positions.go:56:1: exported function TagAltDotEnd should have comment or be unexported
position/positions.go:63:1: exported function BuffStart should have comment or be unexported
position/positions.go:69:1: exported function BuffEnd should have comment or be unexported
position/positions.go:76:1: exported function PrevChar should have comment or be unexported
position/positions.go:84:1: exported function NextChar should have comment or be unexported
position/positions.go:91:1: exported function PrevLine should have comment or be unexported
position/positions.go:126:1: exported function NextLine should have comment or be unexported
position/positions.go:195:1: exported function EndOfLine should have comment or be unexported
position/positions.go:213:1: exported function EndOfLineWithNewline should have comment or be unexported
position/positions.go:230:1: exported function StartOfLine should have comment or be unexported
position/positions.go:246:1: exported function CurWordStart should have comment or be unexported
position/positions.go:270:1: exported function CurWordEnd should have comment or be unexported
position/positions.go:292:1: exported function CurExecutionWordStart should have comment or be unexported
position/positions.go:316:1: exported function CurExecutionWordEnd should have comment or be unexported
position/positions.go:338:1: exported function CurTagExecutionWordStart should have comment or be unexported
position/positions.go:345:1: exported function CurTagExecutionWordEnd should have comment or be unexported
position/positions.go:352:1: exported function CurTagWordStart should have comment or be unexported
position/positions.go:359:1: exported function CurTagWordEnd should have comment or be unexported
position/positions.go:366:1: exported function NextWordStart should have comment or be unexported
position/positions.go:381:1: exported function PrevWordStart should have comment or be unexported
renderer/colors.go:7:1: comment on exported var NormalBackground should be of the form "NormalBackground ..."
renderer/colors.go:9:5: exported var InsertBackground should have comment or be unexported
renderer/colors.go:10:5: exported var DeleteBackground should have comment or be unexported
renderer/colors.go:11:5: exported var TaglineBackground should have comment or be unexported
renderer/colors.go:13:1: comment on exported var TextHighlight should be of the form "TextHighlight ..."
renderer/colors.go:15:5: exported var TextColour should have comment or be unexported
renderer/colors.go:16:5: exported var CommentColour should have comment or be unexported
renderer/colors.go:17:5: exported var KeywordColour should have comment or be unexported
renderer/colors.go:18:5: exported var BuiltinTypeColour should have comment or be unexported
renderer/colors.go:19:5: exported var StringColour should have comment or be unexported
renderer/colors.go:21:1: comment on exported var TagDelimitorColour should be of the form "TagDelimitorColour ..."
renderer/colors.go:23:5: exported var AttributeColour should have comment or be unexported
renderer/colors.go:24:5: exported var TagColour should have comment or be unexported
renderer/colors.go:25:5: exported var OperatorColour should have comment or be unexported
renderer/defaultsizecalcer.go:22:1: exported method DefaultSizeCalcer.InvalidateCache should have comment or be unexported
renderer/defaultsizecalcer.go:25:1: exported method DefaultSizeCalcer.Bounds should have comment or be unexported
renderer/imagemap.go:10:5: exported var ErrNoCharacter should have comment or be unexported
renderer/imagemap.go:12:6: exported type ImageLoc should have comment or be unexported
renderer/imagemap.go:17:6: exported type ImageMap should have comment or be unexported
renderer/imagemap.go:25:1: exported method ImageMap.At should have comment or be unexported
renderer/imagemap.go:34:1: comment on exported method ImageMap.Get should be of the form "Get ..."
renderer/imagemapcacher.go:20:1: exported method DefaultImageMapper.InvalidateCache should have comment or be unexported
renderer/imagemapcacher.go:23:1: exported method DefaultImageMapper.GetImageMap should have comment or be unexported
renderer/init.go:7:5: exported var MonoFontFace should have comment or be unexported
renderer/recalculatefont_darwin.go:12:1: exported function RecalculateFontFace should have comment or be unexported
renderer/register.go:18:1: exported function RegisterRenderer should have comment or be unexported
renderer/register.go:22:1: exported function GetRenderer should have comment or be unexported
renderer/register.go:30:1: exported function GetNamedRenderer should have comment or be unexported
renderer/tagline.go:21:1: exported method TaglineRenderer.InvalidateCache should have comment or be unexported
renderer/tagline.go:26:1: exported method TaglineRenderer.CanRender should have comment or be unexported
renderer/tagline.go:30:1: exported method TaglineRenderer.RenderInto should have comment or be unexported
renderer/gorenderer/gosyntax.go:17:6: exported type GoSyntax should have comment or be unexported
renderer/gorenderer/gosyntax.go:22:1: exported method GoSyntax.InvalidateCache should have comment or be unexported
renderer/gorenderer/gosyntax.go:26:1: exported method GoSyntax.CanRender should have comment or be unexported
renderer/gorenderer/gosyntax.go:30:1: exported method GoSyntax.RenderInto should have comment or be unexported
renderer/gorenderer/gosyntax.go:194:1: exported function StartsLanguageDeliminator should have comment or be unexported
renderer/gorenderer/gosyntax.go:209:1: exported function IsLanguageKeyword should have comment or be unexported
renderer/gorenderer/gosyntax.go:283:1: exported function IsLanguageType should have comment or be unexported
renderer/gorenderer/gosyntax.go:326:1: exported function IsEscaped should have comment or be unexported
renderer/hex/hex.go:14:6: exported type HexRenderer should have comment or be unexported
renderer/hex/hex.go:14:6: type name will be used as hex.HexRenderer by other packages, and that stutters; consider calling this Renderer
renderer/hex/hex.go:16:1: exported method HexRenderer.InvalidateCache should have comment or be unexported
renderer/hex/hex.go:18:1: exported method HexRenderer.CanRender should have comment or be unexported
renderer/hex/hex.go:21:1: exported method HexRenderer.Bounds should have comment or be unexported
renderer/hex/hex.go:40:1: exported method HexRenderer.GetImageMap should have comment or be unexported
renderer/hex/hex.go:43:1: exported method HexRenderer.RenderInto should have comment or be unexported
renderer/html/htmlsyntax.go:17:6: exported type HTMLSyntax should have comment or be unexported
renderer/html/htmlsyntax.go:22:1: exported method HTMLSyntax.InvalidateCache should have comment or be unexported
renderer/html/htmlsyntax.go:26:1: exported method HTMLSyntax.CanRender should have comment or be unexported
renderer/html/htmlsyntax.go:30:1: exported method HTMLSyntax.RenderInto should have comment or be unexported
renderer/imagerenderer/imagerender.go:10:2: a blank import should be only in a main or test package, or have a comment justifying it
renderer/imagerenderer/imagerender.go:14:6: exported type ImageRenderer should have comment or be unexported
renderer/imagerenderer/imagerender.go:18:1: exported method ImageRenderer.InvalidateCache should have comment or be unexported
renderer/imagerenderer/imagerender.go:21:1: exported method ImageRenderer.Bounds should have comment or be unexported
renderer/imagerenderer/imagerender.go:27:1: exported method ImageRenderer.CanRender should have comment or be unexported
renderer/imagerenderer/imagerender.go:53:1: exported method ImageRenderer.RenderInto should have comment or be unexported
renderer/imagerenderer/imagerender.go:61:1: exported method ImageRenderer.GetImageMap should have comment or be unexported
renderer/markdown/markdownsyntax.go:17:6: exported type MarkdownSyntax should have comment or be unexported
renderer/markdown/markdownsyntax.go:22:1: exported method MarkdownSyntax.InvalidateCache should have comment or be unexported
renderer/markdown/markdownsyntax.go:27:1: exported method MarkdownSyntax.CanRender should have comment or be unexported
renderer/markdown/markdownsyntax.go:31:1: exported method MarkdownSyntax.RenderInto should have comment or be unexported
renderer/nosyntax/nosyntax.go:14:1: comment on exported type NoSyntaxRenderer should be of the form "NoSyntaxRenderer ..." (with optional leading article)
renderer/nosyntax/nosyntax.go:20:1: exported method NoSyntaxRenderer.InvalidateCache should have comment or be unexported
renderer/nosyntax/nosyntax.go:24:1: exported method NoSyntaxRenderer.CanRender should have comment or be unexported
renderer/nosyntax/nosyntax.go:28:1: exported method NoSyntaxRenderer.RenderInto should have comment or be unexported
renderer/phprenderer/phpsyntax.go:17:6: exported type PHPSyntax should have comment or be unexported
renderer/phprenderer/phpsyntax.go:22:1: exported method PHPSyntax.InvalidateCache should have comment or be unexported
renderer/phprenderer/phpsyntax.go:27:1: exported method PHPSyntax.CanRender should have comment or be unexported
renderer/phprenderer/phpsyntax.go:31:1: exported method PHPSyntax.RenderInto should have comment or be unexported
renderer/phprenderer/phpsyntax.go:173:1: exported function StartsLanguageDeliminator should have comment or be unexported
renderer/phprenderer/phpsyntax.go:292:1: exported function IsLanguageType should have comment or be unexported
renderer/phprenderer/phpsyntax.go:335:1: exported function IsEscaped should have comment or be unexported
viewer/viewport.go:19:6: exported type Viewport should have comment or be unexported
viewer/viewport.go:33:6: exported type RequestRerender should have comment or be unexported
viewer/viewport.go:35:1: exported method Viewport.Rerender should have comment or be unexported
viewer/viewport.go:39:1: exported method Viewport.GetKeyboardMode should have comment or be unexported
viewer/viewport.go:43:5: exported var ErrKBLocked should have comment or be unexported
viewer/viewport.go:44:5: exported var ErrInvalidViewport should have comment or be unexported
viewer/viewport.go:46:1: exported method Viewport.ResetLocation should have comment or be unexported
viewer/viewport.go:55:1: comment on exported method Viewport.LockKeyboardMode should be of the form "LockKeyboardMode ..."
viewer/viewport.go:66:1: comment on exported method Viewport.UnlockKeyboardMode should be of the form "UnlockKeyboardMode ..."
viewer/viewport.go:78:1: exported method Viewport.SetKeyboardMode should have comment or be unexported
viewer/viewport.go:87:1: exported method Viewport.GetRenderer should have comment or be unexported
viewer/viewport.go:91:1: exported method Viewport.SetRenderer should have comment or be unexported
viewer/viewport.go:96:1: exported method Viewport.SetOption should have comment or be unexported
viewer/viewport.go:124:1: exported method Viewport.RenderInto should have comment or be unexported
```