### PR TITLE
Add vi-like mappings for 'I' and 'A'

### DIFF
--- a/kbmap/normalmode.go
+++ b/kbmap/normalmode.go
@@ -2,6 +2,7 @@ package kbmap
 
 import (
 	//"fmt"
+
 	"github.com/driusan/de/actions"
 	"github.com/driusan/de/demodel"
 	"github.com/driusan/de/position"
@@ -31,21 +32,30 @@ func normalMap(e key.Event, buff *demodel.CharBuffer, v demodel.Viewport) (demod
 		// screen and may need to scroll up
 		return NormalMode, demodel.DirectionUp, nil
 	case key.CodeI:
+		if e.Modifiers&key.ModShift == key.ModShift {
+			actions.MoveCursor(position.StartOfLine, position.StartOfLine, buff)
+		}
+
 		return InsertMode, demodel.DirectionNone, nil
 	case key.CodeA:
 		if buff.Dot.End >= uint(len(buff.Buffer)) {
 			return InsertMode, demodel.DirectionDown, nil
 		}
-		if buff.Buffer[buff.Dot.End] == '\n' {
-			// vi doesn't actually let you navigate your cursor *on top*
-			// of the newline, while de does.
-			// It feels weird to push 'a' there and end up on the next
-			// line, so if we append to the end of a line, just leave
-			// the cursor end where it is,
-			actions.MoveCursor(position.DotEnd, position.DotEnd, buff)
-		} else {
-			actions.MoveCursor(position.NextChar, position.NextChar, buff)
 
+		if e.Modifiers&key.ModShift == key.ModShift {
+			actions.MoveCursor(position.EndOfLine, position.EndOfLine, buff)
+		} else {
+			if buff.Buffer[buff.Dot.End] == '\n' {
+				// vi doesn't actually let you navigate your cursor *on top*
+				// of the newline, while de does.
+				// It feels weird to push 'a' there and end up on the next
+				// line, so if we append to the end of a line, just leave
+				// the cursor end where it is,
+				actions.MoveCursor(position.DotEnd, position.DotEnd, buff)
+			} else {
+				actions.MoveCursor(position.NextChar, position.NextChar, buff)
+
+			}
 		}
 
 		// There's a potentially we pressed 'a' at the very end of the screen and

--- a/kbmap/normalmode.go
+++ b/kbmap/normalmode.go
@@ -33,7 +33,7 @@ func normalMap(e key.Event, buff *demodel.CharBuffer, v demodel.Viewport) (demod
 		return NormalMode, demodel.DirectionUp, nil
 	case key.CodeI:
 		if e.Modifiers&key.ModShift == key.ModShift {
-			actions.MoveCursor(position.StartOfLine, position.StartOfLine, buff)
+			actions.MoveCursor(position.StartOfLineAfterWhitespace, position.StartOfLineAfterWhitespace, buff)
 		}
 
 		return InsertMode, demodel.DirectionNone, nil

--- a/position/positions.go
+++ b/position/positions.go
@@ -243,6 +243,33 @@ func StartOfLine(buff demodel.CharBuffer) (uint, error) {
 	return 0, nil
 }
 
+// StartOfLineAfterWhitespace returns the buffer index of the first character
+// in the current line that is not whitespace, or the end of the line if the
+// line is all whitespace.
+func StartOfLineAfterWhitespace(buff demodel.CharBuffer) (uint, error) {
+	if len(buff.Buffer) == 0 {
+		return 0, ErrInvalid
+	}
+
+	start, err := StartOfLine(buff)
+	if err != nil {
+		return 0, err
+	}
+
+	for i := start; i < uint(len(buff.Buffer)); i++ {
+		if buff.Buffer[i] == '\n' {
+			// The line is all whitespace
+			return i, nil
+		}
+		if buff.Buffer[i] == '\n' || !unicode.IsSpace(rune(buff.Buffer[i])) {
+			return i, nil
+		}
+	}
+
+	return 0, nil
+
+}
+
 func CurWordStart(buff demodel.CharBuffer) (uint, error) {
 	if len(buff.Buffer) == 0 {
 		return 0, ErrInvalid


### PR DESCRIPTION
This PR adds mappings for 'I' and 'A', my favorite vi shortcuts.

'I' starts insert mode before the first non-whitespace character on the current line. If the line is all whitespace, it starts insert mode at the end of the line.

'A' starts insert mode at the end of the line.